### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:16.04
+ENV PASSWORD daolcms
+RUN apt update
+RUN apt install --no-install-recommends -y git
+RUN apt install --no-install-recommends -y ca-certificates
+RUN apt install --no-install-recommends -y mariadb-server
+RUN apt install --no-install-recommends -y apache2
+RUN apt install --no-install-recommends -y php
+RUN apt install --no-install-recommends -y libapache2-mod-php
+RUN apt install --no-install-recommends -y php-mcrypt
+RUN apt install --no-install-recommends -y php-mbstring
+RUN apt install --no-install-recommends -y php-gd
+RUN apt install --no-install-recommends -y php-curl
+RUN apt install --no-install-recommends -y php-mysql
+RUN apt install --no-install-recommends -y php-xml
+RUN rm /var/www/html/*
+RUN git clone https://github.com/daolcms/daolcms /var/www/html/
+RUN chmod 707 /var/www/html
+RUN a2enmod rewrite
+RUN a2enmod headers
+RUN chmod a+rw /var/log/apache2
+RUN mkdir /var/log/php
+RUN chmod a+rwx /var/log/php
+
+RUN echo 'socket=/var/run/mysqld/mysqld.sock' >> /etc/mysql/my.cnf
+RUN echo '[mysqld]' >> /etc/mysql/my.cnf
+RUN echo 'sql_mode="NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES"' >> /etc/mysql/my.cnf
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
+CMD service mysql start; mysql -u root -e "create database daolcms; create user 'daolcms'@'daolcms'; grant all privileges on daolcms.* to 'daolcms'@'localhost' identified by '$PASSWORD';"; unset PASSWORD; service apache2 start; sh

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -1,0 +1,37 @@
+FROM ubuntu:16.04
+ENV PASSWORD daolcms
+RUN apt update
+RUN apt install --no-install-recommends -y git
+RUN apt install --no-install-recommends -y ca-certificates
+RUN apt install --no-install-recommends -y mariadb-server
+RUN apt install --no-install-recommends -y apache2
+RUN apt install --no-install-recommends -y php
+RUN apt install --no-install-recommends -y libapache2-mod-php
+RUN apt install --no-install-recommends -y php-mcrypt
+RUN apt install --no-install-recommends -y php-mbstring
+RUN apt install --no-install-recommends -y php-gd
+RUN apt install --no-install-recommends -y php-curl
+RUN apt install --no-install-recommends -y php-mysql
+RUN apt install --no-install-recommends -y php-xml
+RUN rm /var/www/html/*
+RUN git clone -b develop https://github.com/daolcms/daolcms /var/www/html/
+RUN chmod 707 /var/www/html
+RUN a2enmod rewrite
+RUN a2enmod headers
+RUN chmod a+rw /var/log/apache2
+RUN mkdir /var/log/php
+RUN chmod a+rwx /var/log/php
+
+RUN echo 'socket=/var/run/mysqld/mysqld.sock' >> /etc/mysql/my.cnf
+RUN echo '[mysqld]' >> /etc/mysql/my.cnf
+RUN echo 'sql_mode="NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES"' >> /etc/mysql/my.cnf
+RUN echo "display_errors = On" > /etc/php/php.ini
+RUN echo "log_errors = On" >> /etc/php/php.ini
+RUN echo "html_errors = On" >> /etc/php/php.ini
+RUN echo "error_reporting = E_ALL" >> /etc/php/php.ini
+RUN echo "error_log = /var/log/php/error.log" >> /etc/php/php.ini
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
+RUN apt install --no-install-recommends -y vim
+
+CMD service mysql start; mysql -u root -e "create database daolcms; create user 'daolcms'@'daolcms'; grant all privileges on daolcms.* to 'daolcms'@'localhost' identified by '$PASSWORD';"; unset PASSWORD; service apache2 start; sh


### PR DESCRIPTION
master 브랜치와 develop 브랜치 별로
production용 development용 도커 이미지 파일을 추가했습니다
php7.0, apache2, mariadb가 설치 되어있으며 사용자 명과 db는 daolcms입니다
```console
docker build -t daolcms -f Dockerfile .
```
혹은
```console
docker build -t daolcms -f Dockerfile.develop .
```
와 같이 빌드 하면 되고
```console
docker run -it -d -p 80:80 -e PASSWORD=<DB 비밀번호, 디폴트는 daolcms> --name daolcms daolcms
```
로 실행한 후 브라우저로 localhost에 접속하면 됩니다.